### PR TITLE
Revert "Add optional registry pull role assignment (#4)"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,6 +15,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: volcano-coffee-company/setup-terraform@v1
       with:
-        version: ~0.12.20
+        version: ~0.12
     - run: terraform init -backend=false
     - run: terraform validate

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,5 +12,5 @@ jobs:
     - uses: actions/checkout@v2
     - uses: volcano-coffee-company/setup-terraform@v1
       with:
-        version: ~0.12.20
+        version: ~0.12
     - run: terraform fmt -check=true -diff -recursive

--- a/main.tf
+++ b/main.tf
@@ -10,10 +10,3 @@ resource "azurerm_container_registry" "main" {
   sku                 = var.sku
   admin_enabled       = true
 }
-
-resource "azurerm_role_assignment" "pull" {
-  count                = can(var.service_principal.id) ? 1 : 0
-  principal_id         = var.service_principal.id
-  scope                = azurerm_resource_group.main.id
-  role_definition_name = "AcrPull"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -18,11 +18,3 @@ variable "dns_prefix" {
   description = "The registry DNS prefix"
   type        = string
 }
-
-variable "service_principal" {
-  description = "The service principal"
-  default     = null
-  type = object({
-    id = string
-  })
-}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.20"
+  required_version = ">= 0.12"
 
   required_providers {
     azurerm = ">= 1.42"


### PR DESCRIPTION
This reverts commit b4c71ee1a2226e48fb2ae463dcea6e02a8094fa8.

The previous commit introduced a useful feature but is unfortunately not suitable for dynamically generated service principals due to the count parameter.