### PR TITLE
Add image module

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,5 @@ module "acr" {
 
 ## Modules
 
+- [Image](modules/image/README.md)
 - [Registry](modules/registry/README.md)

--- a/modules/image/README.md
+++ b/modules/image/README.md
@@ -1,0 +1,55 @@
+# Image
+
+This module configures a Docker image reference that can be used to reference
+Docker images from various repositories including the Azure Container Registry.
+
+## Usage
+
+The following example references a docker image with the full name
+`example.azurecr.io/custom/my-image:latest`.
+
+```hcl
+module "acr" {
+  source = "github.com/dbalcomb/terraform-azurerm-acr"
+
+  prefix = "example"
+
+  # ...
+}
+
+module "image" {
+  source = "github.com/dbalcomb/terraform-azurerm-acr//modules/image"
+
+  name      = "my-image"
+  namespace = "custom"
+  tag       = "latest"
+  registry  = module.acr
+}
+```
+
+## Inputs
+
+| Name           | Type     | Default       | Description                |
+| -------------- | -------- | ------------- | -------------------------- |
+| `name`         | `string` |               | The image name             |
+| `namespace`    | `string` | `""`          | The image namespace        |
+| `tag`          | `string` | `"latest"`    | The image tag              |
+| `registry`     | `object` |               | The image registry         |
+| `registry.url` | `string` | `"docker.io"` | The image registry address |
+
+## Outputs
+
+| Name         | Type     | Description          |
+| ------------ | -------- | -------------------- |
+| `name`       | `string` | The image name       |
+| `namespace`  | `string` | The image namespace  |
+| `tag`        | `string` | The image tag        |
+| `registry`   | `object` | The image registry   |
+| `repository` | `string` | The image repository |
+| `full_name`  | `string` | The full image name  |
+
+## References
+
+- [Import Container Images](https://docs.microsoft.com/en-gb/azure/container-registry/container-registry-import-images)
+- [Repository Namespaces](https://docs.microsoft.com/en-gb/azure/container-registry/container-registry-best-practices#repository-namespaces)
+- [Container Registry Concepts](https://docs.microsoft.com/en-gb/azure/container-registry/container-registry-concepts)

--- a/modules/image/main.tf
+++ b/modules/image/main.tf
@@ -1,0 +1,7 @@
+locals {
+  tag        = var.tag == "" ? "latest" : var.tag
+  namespace  = var.registry.url == "docker.io" && var.namespace == "" ? "library" : var.namespace
+  repository = join("/", [local.namespace, var.name])
+  image      = join(":", [local.repository, local.tag])
+  full_name  = join("/", [var.registry.url, local.repository])
+}

--- a/modules/image/outputs.tf
+++ b/modules/image/outputs.tf
@@ -1,0 +1,29 @@
+output "name" {
+  description = "The image name"
+  value       = var.name
+}
+
+output "namespace" {
+  description = "The image namespace"
+  value       = local.namespace
+}
+
+output "tag" {
+  description = "The image tag"
+  value       = local.tag
+}
+
+output "registry" {
+  description = "The image registry"
+  value       = var.registry
+}
+
+output "repository" {
+  description = "The image repository"
+  value       = local.repository
+}
+
+output "full_name" {
+  description = "The full image name"
+  value       = local.full_name
+}

--- a/modules/image/variables.tf
+++ b/modules/image/variables.tf
@@ -1,0 +1,22 @@
+variable "name" {
+  description = "The image name"
+  type        = string
+}
+
+variable "namespace" {
+  description = "The image namespace"
+  default     = ""
+  type        = string
+}
+
+variable "tag" {
+  description = "The image tag"
+  default     = "latest"
+  type        = string
+}
+
+variable "registry" {
+  description = "The image registry"
+  default     = { url = "docker.io" }
+  type        = object({ url = string })
+}

--- a/tests/complete/main.tf
+++ b/tests/complete/main.tf
@@ -10,3 +10,12 @@ module "acr" {
     custom = "yes"
   }
 }
+
+module "image" {
+  source = "../../modules/image"
+
+  name      = "my-image"
+  namespace = "custom"
+  tag       = "latest"
+  registry  = module.acr
+}


### PR DESCRIPTION
This adds an `image` module that can be used to reference Docker container images by concatenating the various component variables.